### PR TITLE
Remove empty value tags

### DIFF
--- a/lib/alfa_insurance/insurance.rb
+++ b/lib/alfa_insurance/insurance.rb
@@ -59,42 +59,48 @@ module AlfaInsurance
       xml.insuredCount(1)
       bus_segments.each_with_index do |segment, index|
         xml.busSegmentRouteNumber(seqNo: index) {
-          xml.value(segment.route_number)
+          xml.value(segment.route_number) if present?(segment.route_number)
         }
         xml.busSegmentPlaceNumber(seqNo: index) {
-          xml.value(segment.place_number)
+          xml.value(segment.place_number) if present?(segment.place_number)
         }
         xml.busSegmentDepartureStation(seqNo: index) {
-          xml.value(segment.departure_station)
+          xml.value(segment.departure_station) if present?(segment.departure_station)
         }
         xml.busSegmentDepartureDate(seqNo: index) {
-          xml.value(segment.departure_date)
+          xml.value(segment.departure_date) if present?(segment.departure_date)
         }
         xml.busSegmentDepartureTime(seqNo: index) {
-          xml.value(segment.departure_time)
+          xml.value(segment.departure_time) if present?(segment.departure_time)
         }
         xml.busSegmentArrivalStation(seqNo: index) {
-          xml.value(segment.arrival_station)
+          xml.value(segment.arrival_station) if present?(segment.arrival_station)
         }
         xml.busSegmentArrivalDate(seqNo: index) {
-          xml.value(segment.arrival_date)
+          xml.value(segment.arrival_date) if present?(segment.arrival_date)
         }
         xml.busSegmentArrivalTime(seqNo: index) {
-          xml.value(segment.arrival_time)
+          xml.value(segment.arrival_time) if present?(segment.arrival_time)
         }
         xml.busSegmentNumber(seqNo: index) {
-          xml.value(segment.number)
+          xml.value(segment.number) if present?(segment.number)
         }
       end
       xml.busSegmentsCount(bus_segments.size)
       xml.ticketInformation {
-          xml.ticketTotalValue(total_value.to_f)
-          xml.ticketIssueDate(ticket_issue_date.iso8601)
-        }
+        xml.ticketTotalValue(total_value.to_f)
+        xml.ticketIssueDate(ticket_issue_date.iso8601)
+      }
       xml.customerPhoneType 'MOBILE'
       xml.customerPhone customer_phone
       xml.customerEmail customer_email
       xml
+    end
+
+    private
+
+    def present?(value)
+      !value.nil? && value != ''
     end
   end
 end

--- a/lib/alfa_insurance/insurance.rb
+++ b/lib/alfa_insurance/insurance.rb
@@ -57,8 +57,6 @@ module AlfaInsurance
       xml.insuredBirthDate(insured_birth_date)
       xml.insuredTicketNumber(insured_ticket_number)
       xml.insuredCount(1)
-#      xml.insuredDocumentType(insured_document_type)
-#      xml.insuredDocumentNumber(insured_document_number)
       bus_segments.each_with_index do |segment, index|
         xml.busSegmentRouteNumber(seqNo: index) {
           xml.value(segment.route_number)

--- a/lib/alfa_insurance/version.rb
+++ b/lib/alfa_insurance/version.rb
@@ -1,3 +1,3 @@
 module AlfaInsurance
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/test/alfa_insurance/bus_insurance_request_test.rb
+++ b/test/alfa_insurance/bus_insurance_request_test.rb
@@ -1,0 +1,162 @@
+require 'test_helper'
+
+describe AlfaInsurance::BusInsuranceRequest do
+  describe '#generate_xml' do
+    before do
+      @segment_data = {
+        route_number: '33',
+        place_number: '14',
+        departure_station: 'Moscow',
+        departure_at: DateTime.parse('2018-03-24 12:00:00+03:00'),
+        arrival_station: 'Kiev',
+        arrival_at: DateTime.parse('2018-03-25 10:00:00+03:00'),
+        number: 1,
+      }
+      @request_data = {
+        insured_first_name: 'Vassily',
+        insured_last_name: 'Poupkine',
+        insured_patronymic: 'Petrovitch',
+        insured_birth_date: '1980-01-01',
+        insured_document_type: 'passport',
+        insured_document_number: '111222',
+        insured_ticket_number: '444555',
+        total_value: Money.from_amount(480, 'RUB'),
+        customer_email: 'test@example.com',
+        customer_phone: '+79161234567',
+      }
+      @ticket_issue_date = Date.parse('2018-03-23')
+    end
+
+    def build_xml
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.root {
+          yield(xml)
+        }
+      end
+      builder.to_xml
+    end
+
+    it 'generates XML with all fields' do
+      segment = AlfaInsurance::BusSegment.new(**@segment_data)
+      request =
+        AlfaInsurance::BusInsuranceRequest.new(
+          **@request_data,
+          bus_segments: [segment],
+        )
+
+      actual_xml = build_xml do |xml|
+        request.generate_xml(xml, @ticket_issue_date)
+      end
+
+      expected_xml = <<~XML
+        <?xml version="1.0"?>
+        <root>
+          <insuredFirstName>Vassily</insuredFirstName>
+          <insuredLastName>Poupkine</insuredLastName>
+          <insuredPatronymic>Petrovitch</insuredPatronymic>
+          <insuredBirthDate>1980-01-01</insuredBirthDate>
+          <insuredTicketNumber>444555</insuredTicketNumber>
+          <insuredCount>1</insuredCount>
+          <busSegmentRouteNumber seqNo="0">
+            <value>33</value>
+          </busSegmentRouteNumber>
+          <busSegmentPlaceNumber seqNo="0">
+            <value>14</value>
+          </busSegmentPlaceNumber>
+          <busSegmentDepartureStation seqNo="0">
+            <value>Moscow</value>
+          </busSegmentDepartureStation>
+          <busSegmentDepartureDate seqNo="0">
+            <value>2018-03-24</value>
+          </busSegmentDepartureDate>
+          <busSegmentDepartureTime seqNo="0">
+            <value>12:00:00</value>
+          </busSegmentDepartureTime>
+          <busSegmentArrivalStation seqNo="0">
+            <value>Kiev</value>
+          </busSegmentArrivalStation>
+          <busSegmentArrivalDate seqNo="0">
+            <value>2018-03-25</value>
+          </busSegmentArrivalDate>
+          <busSegmentArrivalTime seqNo="0">
+            <value>10:00:00</value>
+          </busSegmentArrivalTime>
+          <busSegmentNumber seqNo="0">
+            <value>1</value>
+          </busSegmentNumber>
+          <busSegmentsCount>1</busSegmentsCount>
+          <ticketInformation>
+            <ticketTotalValue>480.0</ticketTotalValue>
+            <ticketIssueDate>2018-03-23</ticketIssueDate>
+          </ticketInformation>
+          <customerPhoneType>MOBILE</customerPhoneType>
+          <customerPhone>+79161234567</customerPhone>
+          <customerEmail>test@example.com</customerEmail>
+        </root>
+      XML
+
+      assert_equal expected_xml, actual_xml
+    end
+
+    it 'skips value tags for empty fields' do
+      # запрос не содержит arrival_at
+      segment_data = @segment_data.merge(arrival_at: nil)
+      segment = AlfaInsurance::BusSegment.new(**segment_data)
+      request =
+        AlfaInsurance::BusInsuranceRequest.new(
+          **@request_data,
+          bus_segments: [segment],
+        )
+
+      actual_xml = build_xml do |xml|
+        request.generate_xml(xml, @ticket_issue_date)
+      end
+
+      # busSegmentArrivalDate и busSegmentArrivalTime не должны содержать тега value
+      expected_xml = <<~XML
+        <?xml version="1.0"?>
+        <root>
+          <insuredFirstName>Vassily</insuredFirstName>
+          <insuredLastName>Poupkine</insuredLastName>
+          <insuredPatronymic>Petrovitch</insuredPatronymic>
+          <insuredBirthDate>1980-01-01</insuredBirthDate>
+          <insuredTicketNumber>444555</insuredTicketNumber>
+          <insuredCount>1</insuredCount>
+          <busSegmentRouteNumber seqNo="0">
+            <value>33</value>
+          </busSegmentRouteNumber>
+          <busSegmentPlaceNumber seqNo="0">
+            <value>14</value>
+          </busSegmentPlaceNumber>
+          <busSegmentDepartureStation seqNo="0">
+            <value>Moscow</value>
+          </busSegmentDepartureStation>
+          <busSegmentDepartureDate seqNo="0">
+            <value>2018-03-24</value>
+          </busSegmentDepartureDate>
+          <busSegmentDepartureTime seqNo="0">
+            <value>12:00:00</value>
+          </busSegmentDepartureTime>
+          <busSegmentArrivalStation seqNo="0">
+            <value>Kiev</value>
+          </busSegmentArrivalStation>
+          <busSegmentArrivalDate seqNo="0"/>
+          <busSegmentArrivalTime seqNo="0"/>
+          <busSegmentNumber seqNo="0">
+            <value>1</value>
+          </busSegmentNumber>
+          <busSegmentsCount>1</busSegmentsCount>
+          <ticketInformation>
+            <ticketTotalValue>480.0</ticketTotalValue>
+            <ticketIssueDate>2018-03-23</ticketIssueDate>
+          </ticketInformation>
+          <customerPhoneType>MOBILE</customerPhoneType>
+          <customerPhone>+79161234567</customerPhone>
+          <customerEmail>test@example.com</customerEmail>
+        </root>
+      XML
+
+      assert_equal expected_xml, actual_xml
+    end
+  end
+end

--- a/test/alfa_insurance_test.rb
+++ b/test/alfa_insurance_test.rb
@@ -5,117 +5,148 @@ describe AlfaInsurance do
     @client = AlfaInsurance::BusClient.new(operator: 'TestBusOperator', product_code: 'TEST-BUS', debug: false)
   end
 
+  def use_vcr_cassette(name)
+    VCR.use_cassette(name, match_requests_on: [:method, :uri, :body]) do
+      yield
+    end
+  end
+
   it '#calculate' do
-    VCR.use_cassette("calculate") do
-      response = @client.calculate(480, Date.new(2018, 4, 1))
-      assert_equal AlfaInsurance::CalculateResponse, response.class
+    ticket_issue_date = Date.new(2018, 6, 13)
+    total_cost = Money.from_amount(480, 'RUB')
+
+    response =
+      use_vcr_cassette('calculate') do
+        @client.calculate(total_cost, ticket_issue_date)
+      end
+
+    assert_equal AlfaInsurance::CalculateResponse, response.class
       assert_equal true, response.success?
       assert_equal 20.0, response.cost.to_f
       assert_equal Money.from_amount(20, 'RUB'), response.cost
       assert_equal Money.from_amount(100000, 'RUB'), response.risk_value
       assert_equal 'RISK_NS', response.risk_type
-    end
   end
 
   it '#create' do
-    VCR.use_cassette("create") do
-      insurance_request = AlfaInsurance::BusInsuranceRequest.new(
-        insured_first_name: 'Vassily',
-        insured_last_name: 'Poupkine',
-        insured_patronymic: 'Petrovitch',
-        insured_birth_date: '1980-01-01',
-        bus_segments: [
-          AlfaInsurance::BusSegment.new(
-            number: 1,
-            route_number: 33,
-            place_number: 14,
-            arrival_station: 'Kiev',
-            arrival_at: DateTime.parse('2018-03-25 00:00:00+03:00'),
-            departure_station: 'Moscow',
-            departure_at: DateTime.parse('2018-03-24 12:00:00+03:00')
-          )
-        ],
-        total_value: Money.from_amount(480, 'RUB'),
-        customer_phone: '+79161234567',
-        customer_email: 'text@example.com'
-      )
-      response = @client.create(insurance_request, Date.new(2018, 4, 1))
-      assert_equal AlfaInsurance::CreateResponse, response.class
-      assert_equal true, response.success?
-      assert_equal Money.from_amount(20, 'RUB'), response.cost
-      assert_equal Money.from_amount(100000, 'RUB'), response.risk_value
-      assert_equal 'RISK_NS', response.risk_type
-      assert_equal 26613228, response.insurance_id
-    end
+    insurance_request = AlfaInsurance::BusInsuranceRequest.new(
+      insured_first_name: 'Vassily',
+      insured_last_name: 'Poupkine',
+      insured_patronymic: 'Petrovitch',
+      insured_birth_date: '1980-01-01',
+      bus_segments: [
+        AlfaInsurance::BusSegment.new(
+          number: 1,
+          route_number: 33,
+          place_number: 14,
+          arrival_station: 'Kiev',
+          arrival_at: DateTime.parse('2018-06-25 00:00:00+03:00'),
+          departure_station: 'Moscow',
+          departure_at: DateTime.parse('2018-06-24 12:00:00+03:00')
+        )
+      ],
+      total_value: Money.from_amount(480, 'RUB'),
+      customer_phone: '+79161234567',
+      customer_email: 'text@example.com'
+    )
+    ticket_issue_date = Date.new(2018, 6, 13)
+
+    response =
+      use_vcr_cassette('create') do
+        @client.create(insurance_request, ticket_issue_date)
+      end
+
+    assert_equal AlfaInsurance::CreateResponse, response.class
+    assert_equal true, response.success?
+    assert_equal Money.from_amount(20, 'RUB'), response.cost
+    assert_equal Money.from_amount(100000, 'RUB'), response.risk_value
+    assert_equal 'RISK_NS', response.risk_type
+    assert_equal 26784313, response.insurance_id
   end
 
   it '#find' do
-    VCR.use_cassette("find") do
-      response = @client.find(26609882)
-      assert_equal true, response.success?
-      assert_equal AlfaInsurance::FindResponse, response.class
-      assert_equal Money.from_amount(20, 'RUB'), response.cost
-      assert_equal Money.from_amount(100000, 'RUB'), response.risk_value
-      assert_equal 'RISK_NS', response.risk_type
-      assert_equal 26609882, response.insurance_id
-      assert_equal 'ISSUING', response.state
-    end
+    response =
+      use_vcr_cassette('find') do
+        @client.find(26784313)
+      end
+
+    assert_equal true, response.success?
+    assert_equal AlfaInsurance::FindResponse, response.class
+    assert_equal Money.from_amount(20, 'RUB'), response.cost
+    assert_equal Money.from_amount(100000, 'RUB'), response.risk_value
+    assert_equal 'RISK_NS', response.risk_type
+    assert_equal 26784313, response.insurance_id
+    assert_equal 'ISSUING', response.state
   end
 
   it '#confirm' do
-    VCR.use_cassette("confirm") do
-      response = @client.confirm(26609882)
-      assert_equal true, response.success?
-      assert_equal AlfaInsurance::ConfirmResponse, response.class
-      assert_equal 26609882, response.insurance_id
-      assert_equal 'https://uat-tes.alfastrah.ru/travel-ext-services/reports?parameters=F30036CA8C9702F23851FC1FD42C48DFBCA1659A0596B2CBC20E3B1DA245709EAAC3034F9B0B6E263831B22E793C176A', response.document_url
-    end
+    response =
+      use_vcr_cassette('confirm') do
+        @client.confirm(26784313)
+      end
+
+    assert_equal true, response.success?
+    assert_equal AlfaInsurance::ConfirmResponse, response.class
+    assert_equal 26784313, response.insurance_id
+    assert_equal 'https://uat-tes.alfastrah.ru/travel-ext-services/reports?parameters=7962FF73070639FEBDCB65C388E284FC2E5FD14B0EE30AE35817FECB2C91604CAAC3034F9B0B6E263831B22E793C176A', response.document_url
   end
 
   it '#cancel' do
-    VCR.use_cassette("cancel") do
-      response = @client.cancel(26609882)
-      assert_equal true, response.success?
-      assert_equal AlfaInsurance::Response, response.class
-    end
+    response =
+      use_vcr_cassette('cancel') do
+        @client.cancel(26784313)
+      end
+
+    assert_equal true, response.success?
+    assert_equal AlfaInsurance::Response, response.class
   end
 
   describe "errors" do
     it 'in find' do
-      VCR.use_cassette("find_error") do
-        response = @client.find(123)
-        assert_equal false, response.success?
-        assert_equal 'POLICY_NOT_FOUND', response.error_code
-        assert_equal 'Can`t find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent', response.error_description
-      end
+      response =
+        use_vcr_cassette('find_error') do
+          @client.find(123)
+        end
+
+      assert_equal false, response.success?
+      assert_equal 'POLICY_NOT_FOUND', response.error_code
+      assert_equal 'Can`t find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent', response.error_description
     end
 
     it 'in confirm' do
-      VCR.use_cassette("confirm_error") do
-        response = @client.confirm(123)
-        assert_equal false, response.success?
-        assert_equal 'POLICY_NOT_FOUND', response.error_code
-        assert_equal 'Can`t find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent', response.error_description
-      end
+      response =
+        use_vcr_cassette('confirm_error') do
+          @client.confirm(123)
+        end
+
+      assert_equal false, response.success?
+      assert_equal 'POLICY_NOT_FOUND', response.error_code
+      assert_equal 'Can`t find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent', response.error_description
     end
 
     it 'in calculate' do
-      VCR.use_cassette("calculate_error") do
-        response = @client.calculate(-100, Date.new(2018, 4, 1))
-        assert_equal false, response.success?
-        assert_equal 'CALCULATION_ERROR', response.error_code
-        assert_equal 'Error: Can`t calculate policy', response.error_description
-      end
+      response =
+        use_vcr_cassette('calculate_error') do
+          @client.calculate(-100, Date.new(2018, 6, 13))
+        end
+
+      assert_equal false, response.success?
+      assert_equal 'CALCULATION_ERROR', response.error_code
+      assert_equal 'Error: Can`t calculate policy', response.error_description
     end
 
     it 'in create' do
-      VCR.use_cassette("create_error") do
+      response =
+        use_vcr_cassette('create_error') do
+          @client.create(
+            AlfaInsurance::BusInsuranceRequest.new(bus_segments: []),
+            Date.new(2018, 6, 13),
+          )
+        end
 
-        response = @client.create(AlfaInsurance::BusInsuranceRequest.new(bus_segments: []), Date.new(2018, 4, 1))
-        assert_equal false, response.success?
-        assert_equal 'BAD_PARAMETER', response.error_code
-        assert_equal 'List of INSURED_FIRST_NAME contains null or empty values', response.error_description
-      end
+      assert_equal false, response.success?
+      assert_equal 'BAD_PARAMETER', response.error_code
+      assert_equal 'List of INSURED_FIRST_NAME contains null or empty values', response.error_description
     end
   end
 end

--- a/test/fixtures/vcr_cassettes/calculate.yml
+++ b/test/fixtures/vcr_cassettes/calculate.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 12:25:42 GMT
+      - Wed, 13 Jun 2018 11:55:28 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,38 +2402,46 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 12:25:41 GMT
+  recorded_at: Wed, 13 Jun 2018 11:55:15 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:calculatePolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:ticketInformation><tns:ticketTotalValue>480.0</tns:ticketTotalValue></tns:ticketInformation></tns:policyParameters></tns:calculatePolicyRequest></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:calculatePolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:ticketInformation><tns:ticketTotalValue>480.0</tns:ticketTotalValue><tns:ticketIssueDate>2018-06-13</tns:ticketIssueDate></tns:ticketInformation></tns:policyParameters></tns:calculatePolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/calculatePolicy"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '607'
+      - '660'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 12:25:42 GMT
+      - Wed, 13 Jun 2018 11:55:32 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,14 +2454,15 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><calculatePolicyResult
-        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion><calculationResult><premium>20.00</premium><currency>RUB</currency><riskValue
+        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion><calculationResult><premium>20.00</premium><currency>RUB</currency><riskValue
         value="100000" riskType="RISK_NS"/><calculationDetails><currency>RUB</currency></calculationDetails><riskValueSum>100000</riskValueSum></calculationResult></calculatePolicyResult></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 12:25:41 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 11:55:16 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/calculate_error.yml
+++ b/test/fixtures/vcr_cassettes/calculate_error.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:18:32 GMT
+      - Wed, 13 Jun 2018 12:08:38 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,38 +2402,46 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:18:30 GMT
+  recorded_at: Wed, 13 Jun 2018 12:08:25 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:calculatePolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:ticketInformation><tns:ticketTotalValue>-100.0</tns:ticketTotalValue></tns:ticketInformation></tns:policyParameters></tns:calculatePolicyRequest></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:calculatePolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:ticketInformation><tns:ticketTotalValue>-100.0</tns:ticketTotalValue><tns:ticketIssueDate>2018-06-13</tns:ticketIssueDate></tns:ticketInformation></tns:policyParameters></tns:calculatePolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/calculatePolicy"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '608'
+      - '661'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:18:32 GMT
+      - Wed, 13 Jun 2018 12:08:42 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,14 +2454,15 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><calculatePolicyResult
         xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>CALCULATION_ERROR</code><errorMessage>Error:
-        Can`t calculate policy</errorMessage><errorMessageID>CE_001</errorMessageID></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion></calculatePolicyResult></soap:Body></soap:Envelope>'
+        Can`t calculate policy</errorMessage><errorMessageID>CE_001</errorMessageID></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion></calculatePolicyResult></soap:Body></soap:Envelope>'
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:18:31 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:08:26 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/cancel.yml
+++ b/test/fixtures/vcr_cassettes/cancel.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 16:55:36 GMT
+      - Wed, 13 Jun 2018 12:05:37 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,20 +2402,20 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 16:55:35 GMT
+  recorded_at: Wed, 13 Jun 2018 12:05:22 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:cancelPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:policyId>26609882</tns:policyId></tns:cancelPolicyRequest></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:cancelPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:policyId>26784313</tns:policyId></tns:cancelPolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/cancelPolicy"'
@@ -2424,17 +2423,25 @@ http_interactions:
       - text/xml;charset=UTF-8
       Content-Length:
       - '440'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 16:55:36 GMT
+      - Wed, 13 Jun 2018 12:05:39 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,13 +2454,14 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><cancelPolicyResult
-        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion></cancelPolicyResult></soap:Body></soap:Envelope>
+        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion></cancelPolicyResult></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 16:55:35 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:05:23 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/confirm.yml
+++ b/test/fixtures/vcr_cassettes/confirm.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 16:49:18 GMT
+      - Wed, 13 Jun 2018 12:04:44 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,20 +2402,20 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 16:49:17 GMT
+  recorded_at: Wed, 13 Jun 2018 12:04:28 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:confirmPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:policyId>26609882</tns:policyId></tns:confirmPolicyRequest></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:confirmPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:policyId>26784313</tns:policyId></tns:confirmPolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/confirmPolicy"'
@@ -2424,17 +2423,25 @@ http_interactions:
       - text/xml;charset=UTF-8
       Content-Length:
       - '442'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 16:49:18 GMT
+      - Wed, 13 Jun 2018 12:04:45 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,13 +2454,14 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><confirmPolicyResult
-        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion><series>888TEST.</series><fullNumber>26609882</fullNumber><policyDocument><url>https://uat-tes.alfastrah.ru/travel-ext-services/reports?parameters=F30036CA8C9702F23851FC1FD42C48DFBCA1659A0596B2CBC20E3B1DA245709EAAC3034F9B0B6E263831B22E793C176A</url></policyDocument></confirmPolicyResult></soap:Body></soap:Envelope>
+        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion><series>888TEST.</series><fullNumber>26784313</fullNumber><policyDocument><url>https://uat-tes.alfastrah.ru/travel-ext-services/reports?parameters=7962FF73070639FEBDCB65C388E284FC2E5FD14B0EE30AE35817FECB2C91604CAAC3034F9B0B6E263831B22E793C176A</url></policyDocument></confirmPolicyResult></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 16:49:17 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:04:29 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/confirm_error.yml
+++ b/test/fixtures/vcr_cassettes/confirm_error.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:12:56 GMT
+      - Wed, 13 Jun 2018 12:07:11 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,15 +2402,15 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:12:54 GMT
+  recorded_at: Wed, 13 Jun 2018 12:06:55 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -2424,17 +2423,25 @@ http_interactions:
       - text/xml;charset=UTF-8
       Content-Length:
       - '437'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:12:56 GMT
+      - Wed, 13 Jun 2018 12:07:12 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,14 +2454,15 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><confirmPolicyResult
         xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>POLICY_NOT_FOUND</code><errorMessage>Can`t
-        find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent</errorMessage><errorMessageID>PNF_007</errorMessageID></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion></confirmPolicyResult></soap:Body></soap:Envelope>'
+        find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent</errorMessage><errorMessageID>PNF_007</errorMessageID></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion></confirmPolicyResult></soap:Body></soap:Envelope>'
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:12:54 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:06:56 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/create.yml
+++ b/test/fixtures/vcr_cassettes/create.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Thu, 15 Mar 2018 08:17:43 GMT
+      - Wed, 13 Jun 2018 12:01:02 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,47 +2402,55 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Thu, 15 Mar 2018 08:17:41 GMT
+  recorded_at: Wed, 13 Jun 2018 12:00:47 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:createPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:insuredFirstName>Vassily</tns:insuredFirstName><tns:insuredLastName>Poupkine</tns:insuredLastName><tns:insuredPatronymic>Petrovitch</tns:insuredPatronymic><tns:insuredBirthDate>1980-01-01</tns:insuredBirthDate><tns:insuredCount>1</tns:insuredCount><tns:busSegmentRouteNumber
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:createPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:insuredFirstName>Vassily</tns:insuredFirstName><tns:insuredLastName>Poupkine</tns:insuredLastName><tns:insuredPatronymic>Petrovitch</tns:insuredPatronymic><tns:insuredBirthDate>1980-01-01</tns:insuredBirthDate><tns:insuredTicketNumber></tns:insuredTicketNumber><tns:insuredCount>1</tns:insuredCount><tns:busSegmentRouteNumber
         seqNo="0"><tns:value>33</tns:value></tns:busSegmentRouteNumber><tns:busSegmentPlaceNumber
         seqNo="0"><tns:value>14</tns:value></tns:busSegmentPlaceNumber><tns:busSegmentDepartureStation
         seqNo="0"><tns:value>Moscow</tns:value></tns:busSegmentDepartureStation><tns:busSegmentDepartureDate
-        seqNo="0"><tns:value>2018-03-24</tns:value></tns:busSegmentDepartureDate><tns:busSegmentDepartureTime
+        seqNo="0"><tns:value>2018-06-24</tns:value></tns:busSegmentDepartureDate><tns:busSegmentDepartureTime
         seqNo="0"><tns:value>12:00:00</tns:value></tns:busSegmentDepartureTime><tns:busSegmentArrivalStation
         seqNo="0"><tns:value>Kiev</tns:value></tns:busSegmentArrivalStation><tns:busSegmentArrivalDate
-        seqNo="0"><tns:value>2018-03-25</tns:value></tns:busSegmentArrivalDate><tns:busSegmentArrivalTime
+        seqNo="0"><tns:value>2018-06-25</tns:value></tns:busSegmentArrivalDate><tns:busSegmentArrivalTime
         seqNo="0"><tns:value>00:00:00</tns:value></tns:busSegmentArrivalTime><tns:busSegmentNumber
-        seqNo="0"><tns:value>1</tns:value></tns:busSegmentNumber><tns:busSegmentsCount>1</tns:busSegmentsCount><tns:ticketInformation><tns:ticketTotalValue>480.00</tns:ticketTotalValue></tns:ticketInformation><tns:customerPhoneType>MOBILE</tns:customerPhoneType><tns:customerPhone>+79161234567</tns:customerPhone><tns:customerEmail>text@example.com</tns:customerEmail></tns:policyParameters></tns:createPolicyRequest></env:Body></env:Envelope>
+        seqNo="0"><tns:value>1</tns:value></tns:busSegmentNumber><tns:busSegmentsCount>1</tns:busSegmentsCount><tns:ticketInformation><tns:ticketTotalValue>480.0</tns:ticketTotalValue><tns:ticketIssueDate>2018-06-13</tns:ticketIssueDate></tns:ticketInformation><tns:customerPhoneType>MOBILE</tns:customerPhoneType><tns:customerPhone>+79161234567</tns:customerPhone><tns:customerEmail>text@example.com</tns:customerEmail></tns:policyParameters></tns:createPolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/createPolicy"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '1917'
+      - '2020'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Thu, 15 Mar 2018 08:17:43 GMT
+      - Wed, 13 Jun 2018 12:01:04 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2456,14 +2463,15 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><createPolicyResult
-        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion><policyId>26613228</policyId><calculationResult><premium>20.00</premium><currency>RUB</currency><riskValue
+        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion><policyId>26784313</policyId><calculationResult><premium>20.00</premium><currency>RUB</currency><riskValue
         value="100000" riskType="RISK_NS"/><calculationDetails><currency>RUB</currency></calculationDetails><riskValueSum>100000</riskValueSum></calculationResult></createPolicyResult></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Thu, 15 Mar 2018 08:17:42 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:00:47 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/create_error.yml
+++ b/test/fixtures/vcr_cassettes/create_error.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:20:19 GMT
+      - Wed, 13 Jun 2018 12:09:41 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,38 +2402,46 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:20:18 GMT
+  recorded_at: Wed, 13 Jun 2018 12:09:27 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:createPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:insuredFirstName/><tns:insuredLastName/><tns:insuredPatronymic/><tns:insuredBirthDate/><tns:insuredCount>1</tns:insuredCount><tns:busSegmentsCount>0</tns:busSegmentsCount><tns:ticketInformation><tns:ticketTotalValue/></tns:ticketInformation><tns:customerPhoneType>MOBILE</tns:customerPhoneType><tns:customerPhone/><tns:customerEmail/></tns:policyParameters></tns:createPolicyRequest></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:createPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:product><tns:code>TEST-BUS</tns:code></tns:product><tns:policyParameters><tns:insuredFirstName></tns:insuredFirstName><tns:insuredLastName></tns:insuredLastName><tns:insuredPatronymic></tns:insuredPatronymic><tns:insuredBirthDate></tns:insuredBirthDate><tns:insuredTicketNumber></tns:insuredTicketNumber><tns:insuredCount>1</tns:insuredCount><tns:busSegmentsCount>0</tns:busSegmentsCount><tns:ticketInformation><tns:ticketTotalValue>0.0</tns:ticketTotalValue><tns:ticketIssueDate>2018-06-13</tns:ticketIssueDate></tns:ticketInformation><tns:customerPhoneType>MOBILE</tns:customerPhoneType><tns:customerPhone></tns:customerPhone><tns:customerEmail></tns:customerEmail></tns:policyParameters></tns:createPolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/createPolicy"'
       Content-Type:
       - text/xml;charset=UTF-8
       Content-Length:
-      - '843'
+      - '1098'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:20:19 GMT
+      - Wed, 13 Jun 2018 12:09:45 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,14 +2454,15 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><createPolicyResult
         xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>BAD_PARAMETER</code><errorMessage>List
-        of INSURED_FIRST_NAME contains null or empty values</errorMessage><errorMessageID>BP_033</errorMessageID></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion></createPolicyResult></soap:Body></soap:Envelope>
+        of INSURED_FIRST_NAME contains null or empty values</errorMessage><errorMessageID>BP_033</errorMessageID></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion></createPolicyResult></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:20:18 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:09:28 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/find.yml
+++ b/test/fixtures/vcr_cassettes/find.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 16:21:29 GMT
+      - Wed, 13 Jun 2018 12:03:30 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,20 +2402,20 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 16:21:28 GMT
+  recorded_at: Wed, 13 Jun 2018 12:03:17 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://vtsft.ru/travelExtService/"
-        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:getPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:policyId>26609882</tns:policyId></tns:getPolicyRequest></env:Body></env:Envelope>
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:getPolicyRequest><tns:operator><tns:code>TestBusOperator</tns:code></tns:operator><tns:policyId>26784313</tns:policyId></tns:getPolicyRequest></env:Body></env:Envelope>
     headers:
       Soapaction:
       - '"http://vtsft.ru/travelExtService/getPolicy"'
@@ -2424,17 +2423,25 @@ http_interactions:
       - text/xml;charset=UTF-8
       Content-Length:
       - '434'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Tue, 13 Mar 2018 16:21:29 GMT
+      - Wed, 13 Jun 2018 12:03:34 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,24 +2454,25 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><getPolicyResult
-        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion><policyInformation><insuredCount>1</insuredCount><insuredFirstName
+        xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>OK</code></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion><policyInformation><insuredCount>1</insuredCount><insuredFirstName
         seqNo="0">Vassily</insuredFirstName><insuredLastName seqNo="0">Poupkine</insuredLastName><insuredPatronymic
         seqNo="0">Petrovitch</insuredPatronymic><insuredBirthDate seqNo="0">1980-01-01</insuredBirthDate><customerPhone>+79161234567</customerPhone><customerPhoneType>MOBILE</customerPhoneType><customerEmail>text@example.com</customerEmail><currency>RUB</currency><policyStatus>ISSUING</policyStatus><riskValue
-        value="100000" riskType="RISK_NS"/><riskCurrency value="RUB" riskType="RISK_NS"/><agent>TestBusAgent</agent><rateRub>20</rateRub><riskList>RISK_NS</riskList><ticketInformation><ticketTotalValue>480.0000</ticketTotalValue></ticketInformation><busSegmentsCount>1</busSegmentsCount><busSegmentRouteNumber
+        value="100000" riskType="RISK_NS"/><riskCurrency value="RUB" riskType="RISK_NS"/><agent>TestBusAgent</agent><rateRub>20</rateRub><riskList>RISK_NS</riskList><ticketInformation><ticketTotalValue>480.0000</ticketTotalValue><ticketIssueDate>2018-06-13T00:00:00.000+03:00</ticketIssueDate></ticketInformation><busSegmentsCount>1</busSegmentsCount><busSegmentRouteNumber
         seqNo="0"><value>33</value></busSegmentRouteNumber><busSegmentPlaceNumber
         seqNo="0"><value>14</value></busSegmentPlaceNumber><busSegmentNumber seqNo="0"><value>1</value></busSegmentNumber><busSegmentDepartureStation
         seqNo="0"><value>Moscow</value></busSegmentDepartureStation><busSegmentDepartureDate
-        seqNo="0"><value>2018-03-24</value></busSegmentDepartureDate><busSegmentDepartureTime
+        seqNo="0"><value>2018-06-24</value></busSegmentDepartureDate><busSegmentDepartureTime
         seqNo="0"><value>12:00:00</value></busSegmentDepartureTime><busSegmentArrivalStation
         seqNo="0"><value>Kiev</value></busSegmentArrivalStation><busSegmentArrivalDate
-        seqNo="0"><value>2018-03-25</value></busSegmentArrivalDate><busSegmentArrivalTime
-        seqNo="0"><value>00:00:00</value></busSegmentArrivalTime><operator>TestBusOperator</operator><product>TEST-BUS</product><policyType>BUS</policyType><rate>20.00</rate><policyID>26609882</policyID><created>2018-03-13T19:07:26.800+03:00</created><lastUpdate>2018-03-13T19:07:26.800+03:00</lastUpdate></policyInformation></getPolicyResult></soap:Body></soap:Envelope>
+        seqNo="0"><value>2018-06-25</value></busSegmentArrivalDate><busSegmentArrivalTime
+        seqNo="0"><value>00:00:00</value></busSegmentArrivalTime><operator>TestBusOperator</operator><product>TEST-BUS</product><policyType>BUS</policyType><rate>20.00</rate><policyID>26784313</policyID><created>2018-06-13T15:00:47.760+03:00</created><lastUpdate>2018-06-13T15:00:47.760+03:00</lastUpdate></policyInformation></getPolicyResult></soap:Body></soap:Envelope>
     http_version: 
-  recorded_at: Tue, 13 Mar 2018 16:21:28 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:03:18 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/find_error.yml
+++ b/test/fixtures/vcr_cassettes/find_error.yml
@@ -6,18 +6,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:09:08 GMT
+      - Wed, 13 Jun 2018 12:06:35 GMT
       Content-Type:
       - text/xml
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -30,7 +38,8 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
@@ -655,7 +664,6 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredPhoneType" nillable="true" type="tns:tesPhoneTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredSex" nillable="true" type="tns:tesSexTypeEnumSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredAddress" nillable="true" type="tns:nonEmptyStringSeqNo"/>
-        <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredIdCard" nillable="true" type="tns:nonEmptyStringSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskValue" nillable="true" type="tns:riskValueSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRate" nillable="true" type="tns:riskRateSeqNo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="insuredRiskRub" nillable="true" type="tns:riskRateSeqNo"/>
@@ -673,7 +681,6 @@ http_interactions:
         <xs:element minOccurs="0" name="insurerPhoneType" type="tns:tesPhoneTypeEnum"/>
         <xs:element minOccurs="0" name="insurerSex" type="tns:tesSexTypeEnum"/>
         <xs:element minOccurs="0" name="insurerAddress" type="xs:string"/>
-        <xs:element minOccurs="0" name="insurerIdCard" type="xs:string"/>
         <xs:element minOccurs="0" name="flightSegmentsCount" type="xs:short"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentTransportOperatorCode" nillable="true" type="tns:stringPolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="flightSegmentFlightNumber" nillable="true" type="tns:stringPolicyInfo"/>
@@ -756,9 +763,7 @@ http_interactions:
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalDate" nillable="true" type="tns:datePolicyInfo"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" name="busSegmentArrivalTime" nillable="true" type="tns:timePolicyInfo"/>
         <xs:element minOccurs="0" name="seatsCount" type="xs:short"/>
-        <xs:element minOccurs="0" name="loanSum" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="monthlyPayment" type="xs:decimal"/>
-        <xs:element minOccurs="0" name="loanTerm" type="xs:int"/>
+        <xs:element minOccurs="0" name="stationNumber" type="xs:string"/>
         </xs:sequence>
         </xs:complexType>
         <xs:complexType name="nonEmptyStringSeqNo">
@@ -1329,7 +1334,6 @@ http_interactions:
         <xs:enumeration value="RISK_PROPERTY"/>
         <xs:enumeration value="RISK_EVENT"/>
         <xs:enumeration value="RISK_LOSS_RESTORE_DOCUMENTS"/>
-        <xs:enumeration value="RISK_LOSS_OF_WORK"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesCurrencyTypeEnum">
@@ -1715,7 +1719,6 @@ http_interactions:
         <xs:enumeration value="INSURED_PHONE_TYPE"/>
         <xs:enumeration value="INSURED_SEX"/>
         <xs:enumeration value="INSURED_ADDRESS"/>
-        <xs:enumeration value="INSURED_ID_CARD"/>
         <xs:enumeration value="INSURER_FIRST_NAME"/>
         <xs:enumeration value="INSURER_LAST_NAME"/>
         <xs:enumeration value="INSURER_PATRONYMIC"/>
@@ -1727,7 +1730,6 @@ http_interactions:
         <xs:enumeration value="INSURER_PHONE_TYPE"/>
         <xs:enumeration value="INSURER_SEX"/>
         <xs:enumeration value="INSURER_ADDRESS"/>
-        <xs:enumeration value="INSURER_ID_CARD"/>
         <xs:enumeration value="FLIGHT_SEGMENTS_COUNT"/>
         <xs:enumeration value="FLIGHT_SEGMENT_TRANSPORT_OPERATOR_CODE"/>
         <xs:enumeration value="FLIGHT_SEGMENT_FLIGHT_NUMBER"/>
@@ -1763,6 +1765,7 @@ http_interactions:
         <xs:enumeration value="EMERGENCY"/>
         <xs:enumeration value="LUGGAGE"/>
         <xs:enumeration value="SEATS_COUNT"/>
+        <xs:enumeration value="STATION_NUMBER"/>
         <xs:enumeration value="SPORT"/>
         <xs:enumeration value="COMPETITION"/>
         <xs:enumeration value="COUNTRY"/>
@@ -1813,9 +1816,6 @@ http_interactions:
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_STATION"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_DATE"/>
         <xs:enumeration value="BUS_SEGMENT_ARRIVAL_TIME"/>
-        <xs:enumeration value="LOAN_SUM"/>
-        <xs:enumeration value="MONTHLY_PAYMENT"/>
-        <xs:enumeration value="LOAN_TERM"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:simpleType name="tesProductParameterTypeEnum">
@@ -1838,7 +1838,6 @@ http_interactions:
         <xs:enumeration value="EVENT"/>
         <xs:enumeration value="BUS"/>
         <xs:enumeration value="TAXI"/>
-        <xs:enumeration value="LOAN"/>
         </xs:restriction>
         </xs:simpleType>
         <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
@@ -2403,15 +2402,15 @@ http_interactions:
           </wsdl:binding>
           <wsdl:service name="TravelExtServiceImplService">
             <wsdl:port binding="tns:TravelExtServiceImplServiceSoapBinding" name="TravelExtServiceImplPort">
-              <soap:address location="http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
+              <soap:address location="https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService"/>
             </wsdl:port>
           </wsdl:service>
         </wsdl:definitions>
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:09:07 GMT
+  recorded_at: Wed, 13 Jun 2018 12:06:20 GMT
 - request:
     method: post
-    uri: http://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
+    uri: https://uat-tes.alfastrah.ru/travel-ext-services/TravelExtService
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -2424,17 +2423,25 @@ http_interactions:
       - text/xml;charset=UTF-8
       Content-Length:
       - '429'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
-      message: ''
+      message: OK
     headers:
       Server:
       - nginx/1.10.3 (Ubuntu)
       Date:
-      - Wed, 14 Mar 2018 11:09:08 GMT
+      - Wed, 13 Jun 2018 12:06:37 GMT
       Content-Type:
       - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -2447,14 +2454,15 @@ http_interactions:
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Cache-Control:
-      - no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0
+      - no-store, no-cache, must-revalidate, max-age=0
+      - post-check=0, pre-check=0
       Pragma:
       - no-cache
     body:
       encoding: UTF-8
       string: '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><getPolicyResult
         xmlns="http://vtsft.ru/travelExtService/"><returnCode><code>POLICY_NOT_FOUND</code><errorMessage>Can`t
-        find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent</errorMessage><errorMessageID>PNF_007</errorMessageID></returnCode><tesVersion><environmentId>UATEnvironment</environmentId><buildVersion>20180226</buildVersion></tesVersion></getPolicyResult></soap:Body></soap:Envelope>'
+        find policy with UID: 123 or Policy not allowed to Agent with Code: TestBusAgent</errorMessage><errorMessageID>PNF_007</errorMessageID></returnCode><tesVersion><environmentId>DEVenvironment</environmentId><buildVersion>20180613</buildVersion></tesVersion></getPolicyResult></soap:Body></soap:Envelope>'
     http_version: 
-  recorded_at: Wed, 14 Mar 2018 11:09:07 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Wed, 13 Jun 2018 12:06:21 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
В ответ на запрос создания страховки приходила ошибка вида:
```xml
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  <soap:Body>
    <soap:Fault>
      <faultcode>soap:Client</faultcode>
      <faultstring>Unmarshalling Error: </faultstring>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>
```

Причина была в том, что для необязательных полей нельзя передавать пустой тег `<value>`.

Сделано:
1. Добавлена проверка на пустоту значения, убраны пустые теги `<value>`.
2. Доработаны тесты VCR. Ранее запросы матчились только по URL и HTTP-методу. Добавлен матчинг по телу запроса ([детали](https://github.com/vcr/vcr/blob/6fb86f588e376af26d20bd44e77e879d96b07b00/lib/vcr.rb#L73-L77)). Это позволяет быть уверенным, что на самом деле происходит то же самое, что и в VCR.